### PR TITLE
Switch search history to local storage

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -115,7 +115,7 @@ function updateCategoryCheckbox(categoryTitle, categoryList) {
 
 // 載入搜尋歷史
 function loadHistory() {
-  chrome.storage.sync.get('searchHistory', (result) => {
+  chrome.storage.local.get('searchHistory', (result) => {
     const history = result.searchHistory || [];
     const historyList = document.getElementById('historyList');
     historyList.innerHTML = '';
@@ -132,7 +132,7 @@ function loadHistory() {
       div.querySelector('.delete-btn').addEventListener('click', (e) => {
         const index = parseInt(e.target.dataset.index);
         history.splice(index, 1);
-        chrome.storage.sync.set({ searchHistory: history }, loadHistory);
+        chrome.storage.local.set({ searchHistory: history }, loadHistory);
       });
       
       historyList.appendChild(div);


### PR DESCRIPTION
## Summary
- save search history with `chrome.storage.local` instead of sync
- update popup to use local storage when reading/deleting history

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b4f6267ac8333ad4200000921bb37