### PR TITLE
feat: guard context menu search without selection

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -106,6 +106,9 @@ function updateContextMenu() {
 
 // 處理選單點擊事件
 chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (!info.selectionText || info.selectionText.trim() === '') {
+    return;
+  }
   const searchTerm = encodeURIComponent(info.selectionText);
   
   chrome.storage.sync.get('sites', (siteResult) => {


### PR DESCRIPTION
## Summary
- avoid creating search history and tabs when context menu activated without selected text

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689440fbdfc08333a2b74bc2bdb82464